### PR TITLE
update argsparser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "docs" ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,4 @@ jobs:
     - name: Check modguard
       run: |
         pip install .
-        modguard check --exclude tests .
+        modguard check --exclude tests

--- a/modguard/cli.py
+++ b/modguard/cli.py
@@ -11,6 +11,9 @@ from modguard.parsing.boundary import build_boundary_trie
 from modguard.colors import BCOLORS
 
 
+MODGUARD_CONFIG_FILE_NAME = "modguard"
+
+
 def print_errors(error_list: list[ErrorInfo]) -> None:
     sorted_results = sorted(error_list, key=lambda e: e.location)
     for error in sorted_results:
@@ -20,16 +23,17 @@ def print_errors(error_list: list[ErrorInfo]) -> None:
         )
 
 
-def print_invalid_path(path: str) -> None:
+def print_no_modguard_yml() -> None:
     print(
-        f"{BCOLORS.FAIL} {path} is not a valid directory! Provide the path of the root of your project.",
+        f"{BCOLORS.FAIL} {MODGUARD_CONFIG_FILE_NAME}.(yml|yaml) not found.",
         file=sys.stderr,
     )
 
 
 def print_invalid_exclude(path: str) -> None:
     print(
-        f"{BCOLORS.FAIL} {path} is not a valid dir or file. Make sure the exclude list is comma separated and valid.",
+        f"{BCOLORS.FAIL} {path} is not a valid dir or file. "
+        f"Make sure the exclude list is comma separated and valid.",
         file=sys.stderr,
     )
 
@@ -43,39 +47,37 @@ def add_base_arguments(parser: argparse.ArgumentParser) -> None:
         metavar="file_or_path,...",
         help="Comma separated path list to exclude. tests/, ci/, etc.",
     )
-    parser.add_argument(
-        "path",
-        type=str,
-        help="The path of the root of your Python project.",
-    )
 
 
-def parse_arguments(args: list[str]) -> argparse.Namespace:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="modguard",
         add_help=True,
-        epilog="Make sure modguard is run from the root of your Python project and that a directory is being specified. For example: `modguard check .`",
+        epilog="Make sure modguard is run from the root of your Python project,"
+        " and `modguard.yml` is present",
     )
     subparsers = parser.add_subparsers(title="commands", dest="command")
     init_parser = subparsers.add_parser(
         "init",
         prog="modguard init",
-        help="Initialize boundaries and mark imported members as public",
-        description="Initialize boundaries with modguard",
+        help="Initialize boundaries between top-level modules and write dependencies to "
+        "`modguard.yml`",
+        description="Initialize boundaries between top-level modules and write dependencies to "
+        "`modguard.yml`",
     )
     add_base_arguments(init_parser)
     check_parser = subparsers.add_parser(
         "check",
         prog="modguard check",
-        help="Check existing boundaries against marked members",
-        description="Check boundaries with modguard",
+        help="Check existing boundaries against your dependencies and module interfaces",
+        description="Check existing boundaries against your dependencies and module interfaces",
     )
     add_base_arguments(check_parser)
     show_parser = subparsers.add_parser(
         "show",
         prog="modguard show",
-        help="Show your existing boundaries and optionally write to yaml",
-        description="Show your existing boundaries in modguard",
+        help="Show your existing boundaries",
+        description="Show your existing boundaries",
     )
     add_base_arguments(show_parser)
     show_parser.add_argument(
@@ -85,12 +87,20 @@ def parse_arguments(args: list[str]) -> argparse.Namespace:
         dest="write",
         action="store_true",
         default=False,
-        help="Write the output to a `modguard.yaml` file",
+        help="Write the output to a `interface.yaml` file",
     )
+    return parser
+
+
+def parse_arguments(args: list[str]) -> argparse.Namespace:
+    parser = build_parser()
     parsed_args = parser.parse_args(args)
-    path = parsed_args.path
-    if not os.path.isdir(path):
-        print_invalid_path(path)
+
+    if not args[0] == "init" and not (
+        os.path.exists(f"{MODGUARD_CONFIG_FILE_NAME}.yml")
+        or os.path.exists(f"{MODGUARD_CONFIG_FILE_NAME}.yaml")
+    ):
+        print_no_modguard_yml()
         sys.exit(1)
     exclude_paths = parsed_args.exclude
     if exclude_paths:
@@ -109,9 +119,9 @@ def parse_arguments(args: list[str]) -> argparse.Namespace:
     return parsed_args
 
 
-def modguard_check(args: argparse.Namespace, exclude_paths: Optional[list[str]] = None):
+def modguard_check(exclude_paths: Optional[list[str]] = None):
     try:
-        result: list[ErrorInfo] = check(args.path, exclude_paths=exclude_paths)
+        result: list[ErrorInfo] = check(".", exclude_paths=exclude_paths)
     except Exception as e:
         stop_spinner()
         print(str(e))
@@ -125,10 +135,10 @@ def modguard_check(args: argparse.Namespace, exclude_paths: Optional[list[str]] 
     sys.exit(0)
 
 
-def modguard_show(args: argparse.Namespace, exclude_paths: Optional[list[str]] = None):
+def modguard_show(write_file: bool, exclude_paths: Optional[list[str]] = None):
     try:
-        bt = build_boundary_trie(args.path, exclude_paths=exclude_paths)
-        _, pretty_result = show(bt, write_file=args.write)
+        bt = build_boundary_trie(".", exclude_paths=exclude_paths)
+        _, pretty_result = show(bt, write_file=write_file)
     except Exception as e:
         stop_spinner()
         print(str(e))
@@ -138,9 +148,9 @@ def modguard_show(args: argparse.Namespace, exclude_paths: Optional[list[str]] =
     sys.exit(0)
 
 
-def modguard_init(args: argparse.Namespace, exclude_paths: Optional[list[str]] = None):
+def modguard_init(exclude_paths: Optional[list[str]] = None):
     try:
-        warnings = init_project(args.path, exclude_paths=exclude_paths)
+        warnings = init_project(root=".", exclude_paths=exclude_paths)
     except Exception as e:
         stop_spinner()
         print(str(e))
@@ -158,13 +168,13 @@ def main() -> None:
     exclude_paths = args.exclude.split(",") if args.exclude else None
     if args.command == "init":
         start_spinner("Initializing...")
-        modguard_init(args, exclude_paths)
+        modguard_init(exclude_paths=exclude_paths)
     elif args.command == "check":
         start_spinner("Scanning...")
-        modguard_check(args, exclude_paths)
+        modguard_check(exclude_paths=exclude_paths)
     elif args.command == "show":
         start_spinner("Scanning...")
-        modguard_show(args, exclude_paths)
+        modguard_show(write_file=args.write, exclude_paths=exclude_paths)
     else:
         print("Unrecognized command")
         exit(1)

--- a/modguard/cli.py
+++ b/modguard/cli.py
@@ -87,7 +87,7 @@ def build_parser() -> argparse.ArgumentParser:
         dest="write",
         action="store_true",
         default=False,
-        help="Write the output to a `interface.yaml` file",
+        help="Write the output to an `interface.yaml` file",
     )
     return parser
 

--- a/modguard/cli.py
+++ b/modguard/cli.py
@@ -25,7 +25,7 @@ def print_errors(error_list: list[ErrorInfo]) -> None:
 
 def print_no_modguard_yml() -> None:
     print(
-        f"{BCOLORS.FAIL} {MODGUARD_CONFIG_FILE_NAME}.(yml|yaml) not found.",
+        f"{BCOLORS.FAIL} {MODGUARD_CONFIG_FILE_NAME}.(yml|yaml) not found in {os.getcwd()}",
         file=sys.stderr,
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import Mock
 import pytest
 
@@ -30,7 +29,7 @@ def mock_path_exists(mocker) -> None:
         if path == "modguard.yml":
             return True
         else:
-            return os.path.exists(path)
+            return False
 
     mocker.patch("modguard.cli.os.path.exists", mock_path_exists)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,8 +26,9 @@ def mock_isdir(mocker) -> None:
 def test_execute_with_valid_dir(capfd, mock_isdir, mock_check):
     # Test with a valid path as mocked
     args = cli.parse_arguments(["check", "valid_dir"])
+    exclude_paths = args.exclude.split(",") if args.exclude else None
     with pytest.raises(SystemExit) as sys_exit:
-        cli.modguard_check(args)
+        cli.modguard_check(exclude_paths=exclude_paths)
     captured = capfd.readouterr()
     assert sys_exit.value.code == 0
     assert "✅" in captured.out
@@ -37,6 +38,7 @@ def test_execute_with_valid_dir(capfd, mock_isdir, mock_check):
 def test_execute_with_error(capfd, mock_isdir, mock_check):
     # Test with a valid path as mocked
     args = cli.parse_arguments(["check", "valid_dir"])
+    exclude_paths = args.exclude.split(",") if args.exclude else None
     # Mock an error returned from check
     location = "valid_dir/file.py"
     message = "Import valid_dir in valid_dir/file.py is blocked by boundary"
@@ -46,7 +48,7 @@ def test_execute_with_error(capfd, mock_isdir, mock_check):
         )
     ]
     with pytest.raises(SystemExit) as sys_exit:
-        cli.modguard_check(args)
+        cli.modguard_check(exclude_paths=exclude_paths)
     captured = capfd.readouterr()
     assert sys_exit.value.code == 1
     assert location in captured.err
@@ -57,7 +59,8 @@ def test_execute_with_invalid_dir(capfd, mock_isdir):
     with pytest.raises(SystemExit) as sys_exit:
         # Test with an invalid path as mocked
         args = cli.parse_arguments(["check", "invalid_dir"])
-        cli.modguard_check(args)
+        exclude_paths = args.exclude.split(",") if args.exclude else None
+        cli.modguard_check(exclude_paths=exclude_paths)
     captured = capfd.readouterr()
     assert sys_exit.value.code == 1
     assert "invalid_dir is not a valid directory" in captured.err
@@ -67,7 +70,8 @@ def test_execute_with_valid_exclude(capfd, mock_isdir, mock_check):
     with pytest.raises(SystemExit) as sys_exit:
         # Test with a valid path as mocked
         args = cli.parse_arguments(["check", "valid_dir", "--exclude", "valid_dir"])
-        cli.modguard_check(args)
+        exclude_paths = args.exclude.split(",") if args.exclude else None
+        cli.modguard_check(exclude_paths=exclude_paths)
     captured = capfd.readouterr()
     assert sys_exit.value.code == 0
     assert "✅" in captured.out
@@ -79,7 +83,8 @@ def test_execute_with_invalid_exclude(capfd, mock_isdir):
         # Test with a valid path as mocked
         # Mock a valid return from check
         args = cli.parse_arguments(["check", "valid_dir", "--exclude", "invalid_dir"])
-        cli.modguard_check(args)
+        exclude_paths = args.exclude.split(",") if args.exclude else None
+        cli.modguard_check(exclude_paths=exclude_paths)
     captured = capfd.readouterr()
     assert sys_exit.value.code == 1
     assert "invalid_dir is not a valid dir or file" in captured.err


### PR DESCRIPTION
Update the argparser to no longer require a path. Instead, check for the presence of a `modguard.yml` in the cwd.
Pass "."  as the default path to check/show/init calls outside of the cli. Updates tests to match and run on 'docs'


- passing test, dev-reqs
- updated readme
- add additional modguard init stuff
- updated readme to show module.yml syntax
- more tweaks
- modguard ignore
- last tweaks
- cap
- remove interface ref
- fix up python quotes
- suggested docs changes
- update back to strict mode, pyright ignores, venv ignore, test venv activate
- updated cli interface
- check local dir
- update docstring
